### PR TITLE
fix: `org-music--log-song-state` placing the state before LOGBOOK

### DIFF
--- a/org-music.el
+++ b/org-music.el
@@ -151,7 +151,8 @@ Used to retrieve songs, playlists on android media player."
         (log-time (format-time-string
                    (org-time-stamp-format 'long 'inactive)(org-current-effective-time))))
     (goto-char log-spos)
-    (insert state ": " log-time "\n")
+    (goto-char (line-end-position))
+    (insert "\n" state ": " log-time)
     (forward-line -1)
     (org-indent-region (line-beginning-position) (line-end-position))
     (save-buffer)


### PR DESCRIPTION
When I use `org-music-enqueue-song-at-point` it is placing the `ENQUEUED` state before the `LOGBOOK`, like that:

```
** A-ha - Take on Me
:PROPERTIES:
:TYPE:     song
:RATE:     5
:END:
ENQUEUED: [2024-11-04 seg 12:09]
:LOGBOOK:
ENQUEUED: [2024-11-04 seg 11:15]
:END:
```

I noticed it was happening because `(org-log-beginning t)` returns the point before the `:LOGBOOK:`.

Check if you can reproduce it, as it may be some bug related to the org version and not a bug in your code itself.